### PR TITLE
ADX-381 Fix accepted member requests 404-ing

### DIFF
--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -63,4 +63,7 @@ echo "Moving test.ini into a subdir..."
 mkdir subdir
 mv test.ini subdir
 
+echo "Initialising ckanext-ytp-request DB tables."
+paster --plugin=ckanext-ytp-request initdb -c subdir/test.ini
+
 echo "travis-build.bash is done."

--- a/ckanext/ytp/request/logic/action/get.py
+++ b/ckanext/ytp/request/logic/action/get.py
@@ -15,13 +15,13 @@ def member_request(context, data_dict):
     mrequest_id = data_dict.get('mrequest_id', None)
 
     membership = model.Session.query(model.Member).get(mrequest_id)
-    if not membership or membership.state != 'pending':
+    if not membership:
         raise logic.NotFound("Member request not found")
 
     # Return most current instance from memberrequest table
     member_request = model.Session.query(MemberRequest).filter(
         MemberRequest.membership_id == mrequest_id).order_by('request_date desc').limit(1).first()
-    if not member_request or member_request.status != 'pending':
+    if not member_request:
         raise logic.NotFound(
             "Member request associated with membership not found")
 
@@ -30,7 +30,7 @@ def member_request(context, data_dict):
     member_dict['organization_name'] = membership.group.name
     member_dict['group_id'] = membership.group_id
     member_dict['role'] = member_request.role
-    member_dict['state'] = 'pending'
+    member_dict['state'] = member_request.status
     member_dict['request_date'] = member_request.request_date.strftime(
         "%d - %b - %Y")
     member_dict['user_id'] = membership.table_id

--- a/ckanext/ytp/request/logic/action/update.py
+++ b/ckanext/ytp/request/logic/action/update.py
@@ -86,7 +86,7 @@ def _process(context, action, data_dict):
     # BFW: In case of pending state overwrite it since it is no final state
     member_request.status = request_status
     member_request.handling_date = datetime.datetime.utcnow()
-    member_request.handled_by = c.userobj.name
+    member_request.handled_by = user
     member_request.message = message
     if role:
         member_request.role = role

--- a/ckanext/ytp/request/logic/action/update.py
+++ b/ckanext/ytp/request/logic/action/update.py
@@ -1,6 +1,5 @@
 from ckan import model, logic
 from ckanext.ytp.request.model import MemberRequest
-from ckan.common import c
 from ckanext.ytp.request.helper import get_default_locale
 from ckanext.ytp.request.mail import mail_process_status
 from ckan.lib.helpers import flash_success

--- a/ckanext/ytp/request/model.py
+++ b/ckanext/ytp/request/model.py
@@ -37,7 +37,7 @@ class MemberRequest(Base):
     id = Column(types.UnicodeText, primary_key=True, default=make_uuid)
     # Reference to the table containing the composite key for organization and
     # user
-    membership_id = Column(types.UnicodeText, ForeignKey(model.Member.id))
+    membership_id = Column(types.UnicodeText)
     request_date = Column(types.DateTime, default=datetime.datetime.now)
     role = Column(types.UnicodeText)
     handling_date = Column(types.DateTime)

--- a/ckanext/ytp/request/model.py
+++ b/ckanext/ytp/request/model.py
@@ -1,7 +1,7 @@
 import uuid
 import datetime
 
-from sqlalchemy import Column, MetaData, ForeignKey
+from sqlalchemy import Column, MetaData
 from sqlalchemy import types
 from sqlalchemy.ext.declarative import declarative_base
 

--- a/ckanext/ytp/request/templates/request/show.html
+++ b/ckanext/ytp/request/templates/request/show.html
@@ -69,9 +69,9 @@
           </div>
         {% else %}
           <div>
-            <span>This request has already been actioned</span>
+            <span>{{ _('This request has already been actioned') }}</span>
             <br>
-            <u>No further action is required</u>
+            <u>{{ _('No further action is required') }}</u>
           </div>
         {% endif %}        
     </div>

--- a/ckanext/ytp/request/templates/request/show.html
+++ b/ckanext/ytp/request/templates/request/show.html
@@ -42,31 +42,38 @@
                 <td>{{ membership.request_date }}</td>
               <tr>
                   <th>{% trans %}State{% endtrans %}</th>
-                  <td>{{ membership.state }}</td>
+                  <td>{{ membership.state|capitalize }}</td>
               </tr>
               <tr>
                   <th>{% trans %}Role{% endtrans %}</th>
                   <td>
-
+                    {% if membership.state == 'pending' %}
                       <select id="field-validroles" name="role">
                       {% for option in roles %}
                           <option  value="{{ option.value }}"{% if option.value == membership.role %} selected="selected"{% endif %}>{{ option.text or option.value }}</option>
                       {% endfor %}
                       </select>
-
+                    {% else %}
+                      <span>{{ membership.role|capitalize }}</span>
+                    {% endif %}                      
                   </td>
               </tr>
           </tbody>
-      </table>
-      <div class="form-actions">
-      {% set locale = h.dump_json({'content': _('Are you sure you want approve this request?')}) %}
-     <a id="request_approve_url" href="{{ h.url_for('member_request_approve', mrequest_id=membership.id) }}" class="btn btn-primary  pull-left" data-module="confirm-action" data-module-i18n="{{ locale }}">{{ _('Approve') }}</a>
-
-      {% set locale = h.dump_json({'content': _('Are you sure you want reject this request?')}) %}
-          <a id="request_reject_url" href="{{ h.url_for('member_request_reject', mrequest_id=membership.id) }}" class="btn btn-danger" data-module="confirm-action" data-module-i18n="{{ locale }}">{{ _('Reject') }}</a>
-
-     </div>
-
+      </table>      
+        {% if membership.state == 'pending' %}
+          <div class="form-actions">
+            {% set locale = h.dump_json({'content': _('Are you sure you want approve this request?')}) %}
+            <a id="request_approve_url" href="{{ h.url_for('member_request_approve', mrequest_id=membership.id) }}" class="btn btn-primary  pull-left" data-module="confirm-action" data-module-i18n="{{ locale }}">{{ _('Approve') }}</a>
+            {% set locale = h.dump_json({'content': _('Are you sure you want reject this request?')}) %}
+            <a id="request_reject_url" href="{{ h.url_for('member_request_reject', mrequest_id=membership.id) }}" class="btn btn-danger" data-module="confirm-action" data-module-i18n="{{ locale }}">{{ _('Reject') }}</a>
+          </div>
+        {% else %}
+          <div>
+            <span>This request has already been actioned</span>
+            <br>
+            <u>No further action is required</u>
+          </div>
+        {% endif %}        
     </div>
   </section>
 {% endblock %}

--- a/ckanext/ytp/request/tests/test_plugin.py
+++ b/ckanext/ytp/request/tests/test_plugin.py
@@ -1,44 +1,65 @@
-"""Tests for plugin.py."""
 # encoding: utf-8
+import logging
+from nose.tools import assert_true, assert_equal
 
-# from nose.tools import assert_raises
+import mock
+import __builtin__ as builtins
+from bs4 import BeautifulSoup
+from ckan.lib.helpers import url_for
+from ckan.common import config
+
 import ckan.model as model
-import ckan.plugins
-# import ckan.tests.factories as factories
-# import ckan.logic as logic
+import ckan.tests.helpers as helpers
+import ckan.tests.factories as factories
+from ckan.model.system_info import get_system_info
+from ckan.tests.helpers import submit_and_follow
 
+webtest_submit = helpers.webtest_submit
+PLUGIN_CONTROLLER = 'ckanext.ytp.request.controller:YtpRequestController'
 
-class TestYTPRequestsPlugin(object):
-    '''Tests for the ckanext.example_iauthfunctions.plugin module.
-
-    Specifically tests that overriding parent auth functions will cause
-    child auth functions to use the overridden version.
+class TestViewingActionedReferral(helpers.FunctionalTestBase):
     '''
-    @classmethod
-    def setup_class(cls):
-        '''Nose runs this method once to setup our test class.'''
-        # Test code should use CKAN's plugins.load() function to load plugins
-        # to be tested.
-        ckan.plugins.load('ytp_request')
+        Test that viewing an already actioned membership request does not 404
+    '''
 
-    def teardown(self):
-        '''Nose runs this method after each test method in our test class.'''
-        # Rebuild CKAN's database after each test method, so that each test
-        # method runs with a clean slate.
-        model.repo.rebuild_db()
+    _load_plugins = (u'ytp_request', )
 
-    @classmethod
-    def teardown_class(cls):
-        '''
-        Nose runs this method once after all the test methods in our class
-        have been run.
-        '''
-        # We have to unload the plugin we loaded, so it doesn't affect any
-        # tests that run after ours.
-        ckan.plugins.unload('ytp_request')
+    @mock.patch('ckanext.ytp.request.logic.action.create.flash_success')
+    @mock.patch('ckanext.ytp.request.logic.action.update.flash_success')
+    def test_admin_config_update(self, mocked_create_flash, mocked_update_flash):
+        app = self._get_test_app()
 
-    def sample_test(self):
-        '''
-        Placeholder test.
-        '''
-        pass
+        # setup
+        org = factories.Organization()
+        sysadmin = factories.Sysadmin()
+        regular_user = factories.User()
+
+        # user creates membership request
+        membership_request = helpers.call_action(
+            'member_request_create',
+            {'user': regular_user['name']},
+            group=org['name'],
+            role='member'
+        )
+
+        # admin approves membership
+        membership_approval = helpers.call_action(
+            'member_request_approve',
+            {'user': sysadmin['name']},
+            approve='approve',
+            mrequest_id=membership_request['id']
+        )
+
+        # admin view membership request page again
+        url = url_for(
+            controller=PLUGIN_CONTROLLER,
+            action='show',
+            mrequest_id=membership_request['id']            
+        )
+        response = app.get(
+            url,
+            extra_environ={'REMOTE_USER': sysadmin['name'].encode('ascii')},
+            status=200
+        )
+
+        # app.get() will raise a "Bad response" error if the page 404s

--- a/ckanext/ytp/request/tests/test_plugin.py
+++ b/ckanext/ytp/request/tests/test_plugin.py
@@ -56,10 +56,11 @@ class TestViewingActionedReferral(helpers.FunctionalTestBase):
             action='show',
             mrequest_id=membership_request['id']            
         )
-        response = app.get(
-            url,
-            extra_environ={'REMOTE_USER': sysadmin['name'].encode('ascii')},
-            status=200
-        )
-
-        # app.get() will raise a "Bad response" error if the page 404s
+        try:
+            app.get(
+                url,
+                extra_environ={'REMOTE_USER': sysadmin['name'].encode('ascii')},
+                status=200
+            )
+        except BadResponseError:
+            self.fail('Membership request failed to display after being actioned')

--- a/ckanext/ytp/request/tests/test_plugin.py
+++ b/ckanext/ytp/request/tests/test_plugin.py
@@ -1,21 +1,15 @@
 # encoding: utf-8
-import logging
-from nose.tools import assert_true, assert_equal
+from nose.tools import assert_equal
 
 import mock
-import __builtin__ as builtins
-from bs4 import BeautifulSoup
 from ckan.lib.helpers import url_for
-from ckan.common import config
 
-import ckan.model as model
 import ckan.tests.helpers as helpers
 import ckan.tests.factories as factories
-from ckan.model.system_info import get_system_info
-from ckan.tests.helpers import submit_and_follow
 
 webtest_submit = helpers.webtest_submit
 PLUGIN_CONTROLLER = 'ckanext.ytp.request.controller:YtpRequestController'
+
 
 class TestViewingActionedReferral(helpers.FunctionalTestBase):
     '''
@@ -24,9 +18,9 @@ class TestViewingActionedReferral(helpers.FunctionalTestBase):
 
     _load_plugins = (u'ytp_request', )
 
-    @mock.patch('ckanext.ytp.request.logic.action.create.flash_success')
-    @mock.patch('ckanext.ytp.request.logic.action.update.flash_success')
-    def test_viewing_actioned_referral(self, mocked_create_flash, mocked_update_flash):
+    @mock.patch('ckanext.ytp.request.logic.action.create.flash_success')  # mock1
+    @mock.patch('ckanext.ytp.request.logic.action.update.flash_success')  # mock2
+    def test_viewing_actioned_referral(self, mock1, mock2):
         app = self._get_test_app()
 
         # setup
@@ -43,7 +37,7 @@ class TestViewingActionedReferral(helpers.FunctionalTestBase):
         )
 
         # admin approves membership
-        membership_approval = helpers.call_action(
+        helpers.call_action(
             'member_request_approve',
             {'user': sysadmin['name']},
             approve='approve',
@@ -54,13 +48,13 @@ class TestViewingActionedReferral(helpers.FunctionalTestBase):
         url = url_for(
             controller=PLUGIN_CONTROLLER,
             action='show',
-            mrequest_id=membership_request['id']            
+            mrequest_id=membership_request['id']
         )
-        try:
-            app.get(
-                url,
-                extra_environ={'REMOTE_USER': sysadmin['name'].encode('ascii')},
-                status=200
-            )
-        except BadResponseError:
-            self.fail('Membership request failed to display after being actioned')
+
+        # test request no longer 404s
+        response = app.get(
+            url,
+            extra_environ={'REMOTE_USER': sysadmin['name'].encode('ascii')},
+            expect_errors=True
+        )
+        assert_equal(response.status_int, 200)

--- a/ckanext/ytp/request/tests/test_plugin.py
+++ b/ckanext/ytp/request/tests/test_plugin.py
@@ -26,7 +26,7 @@ class TestViewingActionedReferral(helpers.FunctionalTestBase):
 
     @mock.patch('ckanext.ytp.request.logic.action.create.flash_success')
     @mock.patch('ckanext.ytp.request.logic.action.update.flash_success')
-    def test_admin_config_update(self, mocked_create_flash, mocked_update_flash):
+    def test_viewing_actioned_referral(self, mocked_create_flash, mocked_update_flash):
         app = self._get_test_app()
 
         # setup


### PR DESCRIPTION
# Problem
- When a membership request has already been actioned and the link is revisited again the page returns a 404
- It gives the impression as if something has gone wrong with the request
- It's also common for other admins within the same org to get an email to the link too, so this is a very common issue

![image](https://user-images.githubusercontent.com/2634482/95069789-17c2c680-06ff-11eb-83de-6b27acc1cfe2.png)


# Solution
- Page no longer returns a 404
- We are clearly explaining that no further action is required
- The status of the membership is also displayed so it's clear if it was `accepted/rejected`

![image](https://user-images.githubusercontent.com/2634482/95070026-6d976e80-06ff-11eb-9d09-c7135da6d868.png)
