### PR TITLE
Adx 284 ckan upgrade 2 9

### DIFF
--- a/ckanext/ytp/request/logic/action/delete.py
+++ b/ckanext/ytp/request/logic/action/delete.py
@@ -1,5 +1,6 @@
 from ckan import model, logic
 from ckanext.ytp.request.model import MemberRequest
+from sqlalchemy import desc
 from sqlalchemy.sql.expression import or_
 from ckan.lib.dictization import model_dictize
 from ckan.common import c
@@ -81,7 +82,7 @@ def _process_request(context, organization_id, member, status):
     # last modified field)
     member_request = model.Session.query(MemberRequest) \
         .filter(MemberRequest.membership_id == member.id) \
-        .order_by('request_date desc').limit(1).first()
+        .order_by(desc(MemberRequest.request_date)).limit(1).first()
 
     # BFW: Create a new instance every time membership status is changed
     message = u'Member request cancelled by own user'

--- a/ckanext/ytp/request/logic/action/get.py
+++ b/ckanext/ytp/request/logic/action/get.py
@@ -3,6 +3,7 @@ from ckan.common import _
 from ckan.lib.dictization import model_dictize
 from ckanext.ytp.request.model import MemberRequest
 from ckanext.ytp.request.helper import get_organization_admins
+from sqlalchemy import desc
 
 import logging
 import ckan.authz as authz
@@ -20,7 +21,7 @@ def member_request(context, data_dict):
 
     # Return most current instance from memberrequest table
     member_request = model.Session.query(MemberRequest).filter(
-        MemberRequest.membership_id == mrequest_id).order_by('request_date desc').limit(1).first()
+        MemberRequest.membership_id == mrequest_id).order_by(desc(MemberRequest.request_date)).limit(1).first()
     if not member_request:
         raise logic.NotFound(
             "Member request associated with membership not found")
@@ -121,7 +122,7 @@ def _membeship_request_list_dictize(obj_list, context):
         # by last modified field)
         member_request = model.Session.query(MemberRequest) \
             .filter(MemberRequest.membership_id == obj.id) \
-            .order_by('request_date desc').limit(1).first()
+            .order_by(desc(MemberRequest.request_date)).limit(1).first()
         # Filter out those with cancel state as there is no need to show them to the end user
         # Show however those with 'rejected' state as user may want to know about them
         # HUOM! If a user creates itself a organization has already a
@@ -160,7 +161,7 @@ def _member_list_dictize(obj_list, context, sort_key=lambda x: x['group_id'], re
         member_request = model.Session.query(MemberRequest) \
             .filter(MemberRequest.membership_id == obj.id) \
             .filter(MemberRequest.status == 'pending') \
-            .order_by('request_date desc').limit(1).first()
+            .order_by(desc(MemberRequest.request_date)).limit(1).first()
         # This should never happen but..
         my_date = ""
         if member_request is not None:

--- a/ckanext/ytp/request/logic/action/update.py
+++ b/ckanext/ytp/request/logic/action/update.py
@@ -4,6 +4,7 @@ from ckanext.ytp.request.helper import get_default_locale
 from ckanext.ytp.request.mail import mail_process_status
 from ckan.lib.helpers import flash_success
 from ckan.common import _
+from sqlalchemy import desc
 import logging
 import datetime
 
@@ -70,7 +71,7 @@ def _process(context, action, data_dict):
     # last modified field)
     member_request = model.Session.query(MemberRequest) \
         .filter(MemberRequest.membership_id == member.id) \
-        .order_by('request_date desc').limit(1).first()
+        .order_by(desc(MemberRequest.request_date)).limit(1).first()
 
     # BFW: In case of pending state overwrite it since it is no final state
     member_request.status = request_status


### PR DESCRIPTION
# Problem 1 - Revision issues
- `new_revision()` on `model.repo` is no longer supported in ckan 2.9
- Turns out it hasn't been needed for a while and you can simply remove it [like others have done](https://github.com/ckan/ckan/pull/4784/files#diff-36c2d8db145e5bc813c23ae9b6a43d56880c593563f19e6afcf83bd67a38ce1bL67)
- So  i've gone ahead and removed it and tested it. It seems to work great now

# Problem 2 - sqlalchemy ordering
- We were getting issues with sqlalchemy not being happy with how we use `order_by`
- I fixed it by using the correct sqlalchemy labelling conventions and it works now