### PR TITLE
ADX-513 Explicitly set the limit param of organization list

### DIFF
--- a/ckanext/ytp/request/controller.py
+++ b/ckanext/ytp/request/controller.py
@@ -19,6 +19,7 @@ class YtpRequestController(BaseController):
         data_dict['all_fields'] = True
         data_dict['groups'] = []
         data_dict['type'] = 'organization'
+        data_dict['limit'] = 1000
         # TODO: Filter our organizations where the user is already a member or
         # has a pending request
         return toolkit.get_action('organization_list')({}, data_dict)


### PR DESCRIPTION
organization_list action has a configurable limit.  It can be set both in the params of the action, and in the ckan config file.  I have decided to set both to a high number 1000, so that we don’t get silent clipping of the list.  I have set both the action param and the ckan config values for readability of the code and to ensure there is no silent clipping of the organization list anywhere else in the system. 

What are the implications of this? In what situations would it be important to clip the list?