### PR TITLE
Adx 986 mail not sent when user requests to be an organisation admin

### DIFF
--- a/ckanext/ytp_request/logic/action/create.py
+++ b/ckanext/ytp_request/logic/action/create.py
@@ -128,7 +128,7 @@ def _get_organization_admins(group_id):
 
 def _get_ckan_admins():
     admins = set(
-        model.Session.query(model.User).filter(model.User.sysadmin is True)
+        model.Session.query(model.User).filter(model.User.sysadmin == True)
     )
 
     return admins

--- a/ckanext/ytp_request/logic/action/create.py
+++ b/ckanext/ytp_request/logic/action/create.py
@@ -128,7 +128,7 @@ def _get_organization_admins(group_id):
 
 def _get_ckan_admins():
     admins = set(
-        model.Session.query(model.User).filter(model.User.sysadmin == True)
+        model.Session.query(model.User).filter(model.User.sysadmin)
     )
 
     return admins

--- a/ckanext/ytp_request/tests/test_regression.py
+++ b/ckanext/ytp_request/tests/test_regression.py
@@ -100,4 +100,3 @@ class TestRegression(object):
 
         # check if mail_new_membership_request has been called
         assert create_mail_new_membership_request_success.call_count > 0
-

--- a/ckanext/ytp_request/tests/test_regression.py
+++ b/ckanext/ytp_request/tests/test_regression.py
@@ -81,3 +81,23 @@ class TestRegression(object):
                 mrequest_id=membership_request['id'],
                 role=invalid_role
             )
+
+    @mock.patch('ckanext.ytp_request.logic.action.create.flash_success')
+    @mock.patch('ckanext.ytp_request.logic.action.create.mail_new_membership_request')
+    def test_send_mail_on_admin_role_request(self, create_mail_new_membership_request_success, app):
+        """
+        Checks if mail received when a user requests an admin role.
+        """
+        org = factories.Organization()
+        regular_user = factories.User()
+
+        helpers.call_action(
+            'member_request_create',
+            {'user': regular_user['name']},
+            group=org['name'],
+            role='admin'
+        )
+
+        # check if mail_new_membership_request has been called
+        assert create_mail_new_membership_request_success.call_count > 0
+


### PR DESCRIPTION
## Description
No email received by sysadmin when a user requests to be admin of an organisation. Fixed on local, also added a regression test.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
