### PR TITLE
ADX-1062 Default to "member" role for new requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ 2.7, 3.9 ]
+        python-version: [ 3.9 ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/ckanext/ytp_request/helper.py
+++ b/ckanext/ytp_request/helper.py
@@ -54,4 +54,4 @@ def get_member_request_list(org_id='hello'):
             lambda x: x['group_id'] == org_id,
             member_requests
         )
-    return member_requests
+    return list(member_requests)

--- a/ckanext/ytp_request/views.py
+++ b/ckanext/ytp_request/views.py
@@ -38,7 +38,7 @@ def new(errors=None, error_summary=None):
     selected_organization = toolkit.request.args.get(
         'selected_organization', None)
     roles = _get_available_roles(context, selected_organization)
-    user_role = 'admin'
+    user_role = 'member'
 
     extra_vars = {'selected_organization': selected_organization, 'organizations': organizations,
                   'errors': errors or {}, 'error_summary': error_summary or {},


### PR DESCRIPTION
## Description

Small change to ensure that the default value when selecting a role to join an organisation is member. 

Also casts the return of the helper `get_member_request_list` from a `FilterObject` to a `list` because an empty FilterObject does not evaluate to False which is why the membership requests table shows in the front end even if there are no membership requests. . 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
